### PR TITLE
Update maas-setup.sh

### DIFF
--- a/maas-setup.sh
+++ b/maas-setup.sh
@@ -155,7 +155,7 @@ juju controllers
 juju add-model hello-kubecon
 
 # Deploy the charm "hello-kubecon", and set a hostname for the ingress
-juju deploy hello-kubecon --config juju-external-hostname=kubecon.test
+juju deploy hello-kubecon
 
 # Deploy the ingress integrator - this is a helper to setup the ingress
 juju deploy nginx-ingress-integrator ingress


### PR DESCRIPTION
I had to remove the config option for `juju deploy hello-kubecon --config juju-external-hostname=kubecon.test`  to make it worked. With  `--config  juju-external-hostname=kubecon.test`  the unit was stuck at ` waiting for Pebble in workload container`:

```
Every 2.0s: juju status --color                                                         B550-AORUS: Tue Mar 15 13:11:05 2022
Model          Controller  Cloud/Region  Version  SLA          Timestamp
hello-kubecon  my-k8s-new  my-k8s-new    2.9.26   unsupported  13:11:05Z

App            Version  Status   Scale  Charm                     Store     Channel  Rev  OS          Address         Message
hello-kubecon           waiting      1  hello-kubecon             charmhub  stable    14  kubernetes  10.152.183.100  installing agent
ingress                 active       1  nginx-ingress-integrator  charmhub  stable    27  kubernetes  10.152.183.162

Unit              Workload  Agent  Address     Ports  Message
hello-kubecon/0*  waiting   idle   10.1.85.13         waiting for Pebble in workload container
ingress/0*        active    idle   10.1.85.14
```


It worked like a charm when using only `juju deploy hello-kubecon`.

Maybe it is worth testing on another machine before applying these changes?
